### PR TITLE
Whitelist base paths that use both http and https

### DIFF
--- a/src/cors-proxy/whitelist.lua
+++ b/src/cors-proxy/whitelist.lua
@@ -78,7 +78,7 @@ function _M:call()
     return true
   end
 
-  local quoted_name = ngx.quote_sql_str("http_://" .. name .. "%")
+  local quoted_name = ngx.quote_sql_str("http%://" .. name .. "%")
   local sql = ("SELECT DISTINCT base_path FROM `api_docs_services` WHERE `base_path` LIKE %s;"):format(quoted_name)
   ngx.log(ngx.DEBUG, 'SQL: ', sql)
   local res, err, errcode, sqlstate = db:query(sql)


### PR DESCRIPTION
Closes https://github.com/3scale/cors-proxy/issues/6

I don't really know how to auto-test it... It would require an integration test, I think.
But it should work as expected, I tried the SQL on the system development DB.