### PR TITLE
Setting an empty default for query-args

### DIFF
--- a/src/cors-proxy/init.lua
+++ b/src/cors-proxy/init.lua
@@ -54,7 +54,7 @@ function _M:rewrite()
     port = url[5] or resty_url.default_port(url[1]),
     host = url[4],
     path = ngx.var.http_x_apidocs_path or ngx.var.uri,
-    args = ngx.var.http_x_apidocs_query or ngx.var.args,
+    args = ngx.var.http_x_apidocs_query or ngx.var.args or '',
     method = METHODS[ngx.var.http_x_apidocs_method],
   }
 


### PR DESCRIPTION
Mainly because PUT,POST and DELETE METHODS