### PR TITLE
Allow underscores in headers

### DIFF
--- a/nginx/main.conf.liquid
+++ b/nginx/main.conf.liquid
@@ -9,6 +9,9 @@ events {
 }
 
 http {
+
+  underscores_in_headers on;
+
   lua_shared_dict whitelist 10m;
   lua_shared_dict prometheus_metrics 10M;
 


### PR DESCRIPTION
Otherwise headers like `-H 'app_key: 111111' ` fail.