### PR TITLE
Do not use original query args

### DIFF
--- a/src/cors-proxy/init.lua
+++ b/src/cors-proxy/init.lua
@@ -54,7 +54,7 @@ function _M:rewrite()
     port = url[5] or resty_url.default_port(url[1]),
     host = url[4],
     path = ngx.var.http_x_apidocs_path or ngx.var.uri,
-    args = ngx.var.http_x_apidocs_query or ngx.var.args or '',
+    args = ngx.var.http_x_apidocs_query or '',
     method = METHODS[ngx.var.http_x_apidocs_method],
   }
 


### PR DESCRIPTION
When a request is sent by ActiveDocs (Swagger UI), it adds a `?_=<timestamp in ms>` in query parameters for cache busting. In case `X-Apidocs-Query` is empty, the API backend receives this query, while I believe it shouldn't.

So, I think the proxy should just forward empty query parameters if nothing is set in `X-Apidocs-Query`.