### PR TITLE
Bump s2i-openresty version in Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test: build
 	docker run --rm cors-proxy-app /tmp/scripts/run --daemon
 
 build: rock
-	s2i build . quay.io/3scale/s2i-openresty-centos7:1.11.2.3-4 cors-proxy-app
+	s2i build . quay.io/3scale/s2i-openresty-centos7:1.11.2.5-1-rover2 cors-proxy-app
 
 rock:
 	luarocks make cors-proxy-scm-1.rockspec

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ apicast-cli start -e development
 Build process uses s2i to package docker image.
 
 ```shell
-s2i build . quay.io/3scale/s2i-openresty-centos7:1.11.2.3-4  cors-proxy-app
+s2i build . quay.io/3scale/s2i-openresty-centos7:1.11.2.5-1-rover2  cors-proxy-app
 ```
 
 You can deploy app to OpenShift by running:
 
 ```shell
-oc new-app quay.io/3scale/s2i-openresty-centos7:1.11.2.3-4~https://github.com/3scale/cors-proxy.git
+oc new-app quay.io/3scale/s2i-openresty-centos7:1.11.2.5-1-rover2~https://github.com/3scale/cors-proxy.git
 ```


### PR DESCRIPTION
With the previous version the container didn't start because of the error:

```/tmp/scripts/run: line 3: exec: apicast-cli: not found```

It looks like it's because `/usr/local/openresty/luajit/bin/` is missing in `PATH`. This commit seems to fix it: https://github.com/3scale/s2i-openresty/commit/75deb4108af92a51186ef968f1d14ae5d8ee2871
The version closest to the current that includes this is `1.11.2.5-1-rover2`. It's also the one used in [OpenShift](https://github.com/3scale/cors-proxy/blob/master/openshift/02-open-resty-imagestream.yml#L11). 