### PR TITLE
[prometheus] move metrics from nginx file to lua

### DIFF
--- a/nginx/main.conf.liquid
+++ b/nginx/main.conf.liquid
@@ -29,12 +29,7 @@ http {
   lua_package_cpath "{{ lua_cpath }};;";
 
   init_by_lua_block {
-    prometheus = require('nginx.prometheus').init("prometheus_metrics")
     require('cors-proxy'):init()
-
-    metric_connections      = prometheus:gauge("nginx_http_connections", "Number of HTTP connections", {"state"})
-    database_connection     = prometheus:gauge("cors_proxy_database_connection", "Database Connection State", {"state"})
-
   }
 
   init_worker_by_lua_block {
@@ -87,30 +82,9 @@ http {
     listen 9145;
     location /metrics {
 
-
-      content_by_lua '
-        local response = ngx.location.capture "/nginx_status"
-        local select = select
-        local find = string.find
-
-        if response.status ~= 200 then
-          ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
-          ngx.log(ngx.ERR, "Nginx Status Module is not responding and failing with the Status: ", response.status)
-          ngx.exit(ngx.status)
-        end
-
-        local accepted, handled, total = select(3, find(response.body, [[accepts handled requests\n (%d*) (%d*) (%d*)]]))
-
-        if ngx.var.connections_active ~= nil then
-          metric_connections:set(ngx.var.connections_reading, {"reading"})
-          metric_connections:set(ngx.var.connections_waiting, {"waiting"})
-          metric_connections:set(ngx.var.connections_writing, {"writing"})
-          metric_connections:set(accepted, {"accepted"})
-          metric_connections:set(handled, {"handled"})
-          metric_connections:set(total, {"total"})
-        end
-        prometheus:collect()
-      ';
+      content_by_lua_block {
+        require('cors-proxy'):metrics()
+      }
     }
 
     location /nginx_status {

--- a/nginx/main.conf.liquid
+++ b/nginx/main.conf.liquid
@@ -79,7 +79,13 @@ http {
   }
 
   server {
-    listen 9145;
+    {% if metrics_port %}
+      listen {{ metrics_port }};
+      server_name metrics;
+    {% else %}
+      listen 9145 default_server;
+    {% endif %}
+
     location /metrics {
 
       content_by_lua_block {

--- a/src/cors-proxy/init.lua
+++ b/src/cors-proxy/init.lua
@@ -3,6 +3,8 @@ local resty_resolver = require('resty.resolver')
 local resty_url = require('resty.url')
 local whitelist = require('cors-proxy.whitelist')
 
+local prometheus = require('nginx.prometheus').init("prometheus_metrics")
+
 local METHODS = {
   GET = ngx.HTTP_GET,
   HEAD = ngx.HTTP_HEAD,
@@ -21,11 +23,20 @@ local METHODS = {
   TRACE = ngx.HTTP_TRACE,
 }
 
+local select = select
+local find = string.find
+local tonumber = tonumber
+
 local _M = {
   _VERSION = '0.1',
   balancer = balancer:new(),
   whitelist = whitelist:new(),
   resolver = resty_resolver
+}
+
+local metrics = {
+  http_connections = prometheus:gauge("nginx_http_connections", "Number of HTTP connections", {"state"}),
+  database_connection = prometheus:gauge("cors_proxy_database_connection", "Database Connection State", {"state"}),
 }
 
 function _M:init()
@@ -134,6 +145,28 @@ function _M:upstream()
   end
 
   return balancer:call()
+end
+
+function _M:metrics()
+  local response = ngx.location.capture "/nginx_status"
+
+  if response.status ~= 200 then
+    ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+    ngx.log(ngx.ERR, "Nginx Status Module is not responding and failing with the Status: ", response.status)
+    ngx.exit(ngx.status)
+  end
+
+  local accepted, handled, total = select(3, find(response.body, [[accepts handled requests\n (%d*) (%d*) (%d*)]]))
+
+  metrics.http_connections:set(tonumber(ngx.var.connections_reading) or 0, {"reading"})
+  metrics.http_connections:set(tonumber(ngx.var.connections_waiting) or 0, {"waiting"})
+  metrics.http_connections:set(tonumber(ngx.var.connections_writing) or 0, {"writing"})
+  metrics.http_connections:set(tonumber(ngx.var.connections_active) or 0, {"active"})
+  metrics.http_connections:set(accepted or 0, {"accepted"})
+  metrics.http_connections:set(handled or 0, {"handled"})
+  metrics.http_connections:set(total or 0, {"total"})
+
+  prometheus:collect()
 end
 
 return _M

--- a/t/metrics.t
+++ b/t/metrics.t
@@ -1,0 +1,67 @@
+BEGIN {
+    $ENV{TEST_NGINX_APICAST_BINARY} ||= 'rover exec apicast-cli';
+}
+
+use lib 't';
+use Test::APIcast::Blackbox 'no_plan';
+
+push @Test::Nginx::Util::BlockPreprocessors, sub {
+    my $block = shift;
+
+    my $Workers = $Test::Nginx::Util::Workers;
+    my $MasterProcessEnabled = $Test::Nginx::Util::MasterProcessEnabled;
+    my $DaemonEnabled = $Test::Nginx::Util::DaemonEnabled;
+    my $err_log_file = $block->error_log_file || $Test::Nginx::Util::ErrLogFile;
+    my $LogLevel = $Test::Nginx::Util::LogLevel;
+    my $PidFile = $Test::Nginx::Util::PidFile;
+    my $AccLogFile = $Test::Nginx::Util::AccLogFile;
+    my $ServerPort = $Test::Nginx::Util::ServerPort;
+    my $sites_d = $block->sites_d;
+
+    my $environment= <<_EOC_;
+return {
+    worker_processes = '$Workers',
+    master_process = '$MasterProcessEnabled',
+    daemon = '$DaemonEnabled',
+    error_log = '$err_log_file',
+    log_level = '$LogLevel',
+    lua_path = '$ENV{LUA_PATH}',
+    lua_cpath = '$ENV{LUA_CPATH}',
+    pid = '$PidFile',
+    lua_code_cache = 'on',
+    access_log = '$AccLogFile',
+    port = '$ServerPort',
+    metrics_port = '$ServerPort',
+    env = { },
+    sites_d = [============================[$sites_d]============================],
+}
+_EOC_
+
+    $block->set_value("environment",$environment);
+};
+
+repeat_each(2);
+run_tests();
+
+__DATA__
+
+=== TEST 1: GET /metrics
+Responds with prometheus metrics
+--- request
+GET /metrics
+--- more_headers
+Host: metrics
+--- response_body
+# HELP nginx_http_connections Number of HTTP connections
+# TYPE nginx_http_connections gauge
+nginx_http_connections{state="accepted"} 0
+nginx_http_connections{state="active"} 1
+nginx_http_connections{state="handled"} 0
+nginx_http_connections{state="reading"} 0
+nginx_http_connections{state="total"} 0
+nginx_http_connections{state="waiting"} 0
+nginx_http_connections{state="writing"} 1
+# HELP nginx_metric_errors_total Number of nginx-lua-prometheus errors
+# TYPE nginx_metric_errors_total counter
+nginx_metric_errors_total 0
+--- error_code: 200


### PR DESCRIPTION
* and fix reporting errors


now when starting the proxy:

```
$ curl localhost:9145/metrics
nginx_http_connections{state="accepted"} 0
nginx_http_connections{state="active"} 1
nginx_http_connections{state="handled"} 0
nginx_http_connections{state="reading"} 0
nginx_http_connections{state="total"} 0
nginx_http_connections{state="waiting"} 0
nginx_http_connections{state="writing"} 1
nginx_metric_errors_total 0
```

# TODO:

- [x] rebase this on top of https://github.com/3scale/cors-proxy/pull/24
- [x] write a test 