### PR TITLE
log request headers when X-ApiDocs-Debug header is set

### DIFF
--- a/nginx/main.conf.liquid
+++ b/nginx/main.conf.liquid
@@ -37,7 +37,7 @@ http {
   }
 
   log_by_lua_block {
-    -- custom logging
+    require('cors-proxy'):log()
   }
 
   upstream proxy {

--- a/t/blackbox.t
+++ b/t/blackbox.t
@@ -73,3 +73,26 @@ location = /t {
 --- response_body
 success!
 --- error_code: 200
+
+
+
+=== TEST 3: print upstream request info
+When X-ApiDocs-Debug header is set
+--- request
+GET /
+--- more_headers eval
+<<HTTP_HEADERS
+X-ApiDocs-URL: http://test:$ENV{TEST_NGINX_SERVER_PORT}/ignored
+X-ApiDocs-Path: /t
+X-ApiDocs-Debug: true
+Forwarded: proto=https;
+HTTP_HEADERS
+--- upstream
+location = /t {
+  echo "success!";
+}
+--- response_body
+success!
+--- error_code: 200
+--- error_log
+Forwarded: proto=https;


### PR DESCRIPTION
So we can debug what was sent to upstream.